### PR TITLE
Add failing unserialize integer overflow test

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -61,7 +61,8 @@ http://pear.php.net/dtd/package-2.0.xsd">
     <file name="001.phpt" role="test" />
     <file name="add.phpt" role="test" />
     <file name="construct.phpt" role="test" />
-    <file name="has.phpt" role="test" />         
+    <file name="has.phpt" role="test" />
+    <file name="unserialize_integer_overflow.phpt" role="test" />
    </dir>
   </dir>
  </contents>

--- a/tests/unserialize_integer_overflow.phpt
+++ b/tests/unserialize_integer_overflow.phpt
@@ -1,0 +1,18 @@
+--TEST--
+unserialize with integer overflow test
+--SKIPIF--
+<?php if (!extension_loaded("bloomy")) print "skip"; ?>
+--FILE--
+<?php
+$bf = new BloomFilter(100, 0.01);
+
+$bf->add("foo");
+
+var_dump(unserialize(serialize($bf)));
+
+$int = 9223372036854775808;
+
+?>
+--EXPECTF--
+object(BloomFilter)#%d (0) {
+}


### PR DESCRIPTION
This is a weird bug I encountered. When having a script that contains an integer overflow, unserializing `BloomFilter` objects errors:

**PHP 5**

```
Notice: unserialize(): Error at offset 24 of 195 bytes
```

**PHP 7**

```
php: symbol lookup error: modules/bloomy.so: undefined symbol: smart_str_appendl
```

See attached test case.

Maybe this is related to #6 
