### PR TITLE
make serialize/unserialize work in php7

### DIFF
--- a/test-bloomy.php
+++ b/test-bloomy.php
@@ -1,0 +1,43 @@
+<?php
+
+$bf = new BloomFilter(100);
+print_r($bf->getInfo());
+
+$words = array(
+    'Hello', 'World', 'Good', 'Better', 'Best',
+    '中国', '世界', '公司', '旅游', '电影', 'PHP是世界上最好的语言'
+);
+
+foreach ($words as $item) {
+    echo 'add ', $item, "\n";
+    $bf->add($item);
+}
+
+print_r($bf->getInfo());
+
+foreach ($words as $item) {
+    echo 'has ', $item, ' ? ';
+    if ($bf->has($item)) {
+        echo 'yes';
+    } else {
+        echo 'no';
+    }
+    echo "\n";
+}
+
+echo "\n\nserialize to /tmp/test-bloomy.data\n";
+file_put_contents('/tmp/test-bloomy.data', serialize($bf));
+unset($bf);
+
+echo "unserialize and test again\n";
+$bf2 = unserialize(file_get_contents('/tmp/test-bloomy.data'));
+print_r($bf2->getInfo());
+foreach ($words as $item) {
+    echo 'has ', $item, ' ? ';
+    if ($bf2->has($item)) {
+        echo 'yes';
+    } else {
+        echo 'no';
+    }
+    echo "\n";
+}


### PR DESCRIPTION
Two changes:
1. ext/standard/php_smart_string.h -> Zend/zend_smart_str.h
2. zval

I am not familiar with php extension development, just some C fundamentals, and I have no idea about how to write serialize/unserialize phpt tests, as the serialized data has some unprintable characters, so I write a php script (test-bloomy.php) for test purpose.
